### PR TITLE
Fixed minimum movie card width to 90px

### DIFF
--- a/src/MovieCard.css
+++ b/src/MovieCard.css
@@ -10,6 +10,7 @@
     font-family: --lucida-font;
     transition: all 0.2s;
     margin: 1px;
+    min-width: 90px;
 }
 
 .moviecard:hover {


### PR DESCRIPTION
### Summary
Made minimum movie card width 90 px to keep movie title in moviecard during re-sizing
### Tests
Full screen and half screen, title never goes out of moviecard